### PR TITLE
Update wiki navigation.md to add GDSA (530) link

### DIFF
--- a/navigation.md
+++ b/navigation.md
@@ -90,6 +90,7 @@ SANS Defense
 -   ----
 - **Blue Team Certifications**
 - <a href='https://giac.org/gcda' target='_blank'>GCDA - 555</a>
+- <a href='https://giac.org/gdsa' target='_blank'>GDSA - 530</a>
 - <a href='https://giac.org/gmon' target='_blank'>GMON - 511</a>
 - <a href='https://giac.org/gcia' target='_blank'>GCIA - 503</a>
 - <a href='https://giac.org/gcwn' target='_blank'>GCWN - 505</a>


### PR DESCRIPTION
This change adds a new link in the class wiki global navigation: Blue Team Certifications > GDSA - 530.